### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,5 +4,6 @@ author=Frank Bösing
 maintainer=Frank Boesing<frank@mynety.net>
 sentence=Fast CRC routines
 paragraph=
+category=Data Processing
 url=https://github.com/FrankBoesing/FastCRC
 architectures=avr, sam, arm


### PR DESCRIPTION
Because no category is specified Arduino IDE 1.6.6 displays the warning:
`WARNING: Category '' in libraryFastCRC is not valid. Setting to 'Uncategorized'`
Every time any sketch is compiled, even if it doesn't include FastCRC.
