### PR TITLE
Fix FastCRC32::crc32_upd and FastCRC16::x25_upd

### DIFF
--- a/FastCRCsw.cpp
+++ b/FastCRCsw.cpp
@@ -364,9 +364,9 @@ uint16_t FastCRC16::x25_upd(const uint8_t *data, uint16_t len)
 		crc = (crc >> 8) ^ pgm_read_word(&crc_table_x25[(crc & 0xff) ^ *data++]);
 	}
 
+	seed = crc;
 	crc = ~crc;
 
-	seed = crc;
 	return crc;
 }
 
@@ -440,9 +440,9 @@ uint32_t FastCRC32::crc32_upd(const uint8_t *data, uint16_t len)
 		crc = (crc >> 8) ^ pgm_read_dword(&CRC_TABLE_CRC32[(crc & 0xff) ^ *data++]);
 	}
 
+	seed = crc;
 	crc = ~crc;
 
-	seed = crc;
 	return crc;
 }
 


### PR DESCRIPTION
Capture seed prior to crc inversion. Similar to fixes in 3ca0800f6a3c6b4b65ff37c8f8773c8d1a4aa08f.