### PR TITLE
Added support for ARM

### DIFF
--- a/FastCRC_tables.h
+++ b/FastCRC_tables.h
@@ -31,7 +31,7 @@
 #define FastCRC_tables
 #include "inttypes.h"
 
-#if !defined(__SAM3X8E__)
+#if !defined(__SAM3X8E__) && !defined(__arm__)
 #if defined(__AVR__ ) || defined(__IMXRT1052__) || defined(__IMXRT1062__) || defined(ARDUINO_ARCH_STM32F1)
 #include <avr/pgmspace.h>
 #else


### PR DESCRIPTION
When compiling for ARM boards, I got this error:
```
In file included from ....\Arduino\libraries\FastCRC\FastCRCsw.cpp:38:0:

....\Arduino\libraries\FastCRC\FastCRC_tables.h:38:23: fatal error: pgmspace.h: No such file or directory

 #include <pgmspace.h> 

                       ^

compilation terminated.

exit status 1
```

This commit fixes that error.