### PR TITLE
Mocking PROGMEM on non Arduino platforms

### DIFF
--- a/src/FastCRC_tables.h
+++ b/src/FastCRC_tables.h
@@ -40,7 +40,10 @@
 #endif
 #endif
 #endif
-
+#ifndef PROGMEM
+// usefull if you're trying to test the lib in a non arduino env (in cppyy on x64 for exemple)
+#define PROGMEM
+#endif
 const uint8_t crc_table_crc7[256] PROGMEM = {
 	0x00, 0x12, 0x24, 0x36, 0x48, 0x5a, 0x6c, 0x7e,
 	0x90, 0x82, 0xb4, 0xa6, 0xd8, 0xca, 0xfc, 0xee,

--- a/src/FastCRC_tables.h
+++ b/src/FastCRC_tables.h
@@ -43,6 +43,7 @@
 #ifndef PROGMEM
 // usefull if you're trying to test the lib in a non arduino env (in cppyy on x64 for exemple)
 #define PROGMEM
+#define PROGMEM_MOCK_ACTIVE
 #endif
 const uint8_t crc_table_crc7[256] PROGMEM = {
 	0x00, 0x12, 0x24, 0x36, 0x48, 0x5a, 0x6c, 0x7e,
@@ -1586,4 +1587,10 @@ const uint32_t crc_table_cksum_big[1024] PROGMEM = {
 	0x105ee293, 0xa7c48f4f, 0xc976f82f, 0x7eec95f3,
 	0x151217ef, 0xa2887a33, 0xcc3a0d53, 0x7ba0608f
 };
+
+#ifdef PROGMEM_MOCK_ACTIVE
+// limit the effect of the progmem mock to this file
+#undef PROGMEM
+#undef PROGMEM_MOCK_ACTIVE
+#endif
 #endif


### PR DESCRIPTION
Hey @FrankBoesing, 

I'd like to thank you first for this amazing library you brought us. It is VERY usefull :)
So useful in fact that I decided to include it in a large project that spans across multiple type of devices including the laptop I'm using to write this.
As I'm trying to load your module in a python vm (using cppyy), I realized that Progmem seems to create a compatibly issue (it is obviously not present in the compiler for x86).

I therefore added flags to replace it by nothing if not existent.

Hope you'll find this useful :)

Bye and thanks a lot for your work