### PR TITLE
Fixed Arduino bug

### DIFF
--- a/src/FastCRC_tables.h
+++ b/src/FastCRC_tables.h
@@ -36,7 +36,7 @@
 #include <avr/pgmspace.h>
 #else
 #if defined(ARDUINO)
-#include <pgmspace.h>	
+#include <avr/pgmspace.h>	
 #endif
 #endif
 #endif

--- a/src/FastCRC_tables.h
+++ b/src/FastCRC_tables.h
@@ -32,11 +32,11 @@
 #include <inttypes.h>
 
 #if !defined(__SAM3X8E__)
-#if defined(__AVR__ ) || defined(__IMXRT1062__) || defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_SAMD)
+#if defined(__AVR__ ) || defined(__IMXRT1062__) || defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_UNOR4_MINIMA) || defined(ARDUINO_UNOR4_WIFI)
 #include <avr/pgmspace.h>
 #else
-#if defined(ARDUINO)
-#include <avr/pgmspace.h>	
+#if defined(ARDUINO) || defined(ARDUINO_ARCH_ESP32)
+#include <pgmspace.h>	
 #endif
 #endif
 #endif


### PR DESCRIPTION
The current Arduino core library has pgmspace.h in the avr/ subfolder.  I am using Arduino Uno Minima and Uno Wifi.  Unable to build on Arduino without the change included in this pull request.  Thank for you for your hard work!