### PR TITLE
Added #defines for compatibility with ESP32 Nano / R4 Minima and R4 Uno Wifi 

### DIFF
--- a/src/FastCRC_tables.h
+++ b/src/FastCRC_tables.h
@@ -32,7 +32,7 @@
 #include <inttypes.h>
 
 #if !defined(__SAM3X8E__)
-#if defined(__AVR__ ) || defined(__IMXRT1062__) || defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_UNOR4_MINIMA) || defined(ARDUINO_UNOR4_WIFI)
+#if defined(__AVR__ ) || defined(__IMXRT1062__) || defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_UNOR4_MINIMA) || defined(ARDUINO_UNOR4_WIFI) || defined(ARDUINO_NANO_RP2040_CONNECT)
 #include <avr/pgmspace.h>
 #else
 #if defined(ARDUINO) || defined(ARDUINO_ARCH_ESP32)

--- a/src/FastCRC_tables.h
+++ b/src/FastCRC_tables.h
@@ -36,7 +36,7 @@
 #include <avr/pgmspace.h>
 #else
 #if defined(ARDUINO)
-#include <pgmspace.h>	
+#include <avr/pgmspace.h>	
 #endif
 #endif
 #endif

--- a/src/FastCRC_tables.h
+++ b/src/FastCRC_tables.h
@@ -32,11 +32,11 @@
 #include <inttypes.h>
 
 #if !defined(__SAM3X8E__)
-#if defined(__AVR__ ) || defined(__IMXRT1062__) || defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_SAMD)
+#if defined(__AVR__ ) || defined(__IMXRT1062__) || defined(ARDUINO_ARCH_STM32F1) || defined(ARDUINO_ARCH_SAMD) || defined(ARDUINO_UNOR4_MINIMA) || defined(ARDUINO_UNOR4_WIFI)
 #include <avr/pgmspace.h>
 #else
-#if defined(ARDUINO)
-#include <avr/pgmspace.h>	
+#if defined(ARDUINO) || defined(ARDUINO_ARCH_ESP32)
+#include <pgmspace.h>	
 #endif
 #endif
 #endif


### PR DESCRIPTION
This is a correction of my prior pull request.  These changes add additional checks for the ESP32 Nano, R4 Minima and R4 Uno Wifi.  Without the proposed changes, compiling fails because of pgmspace.h not being found.  Sadly, the placement of this .h is not consistent across boards, as you are aware.

The changes included in this pull have been tested and confirmed with each of the aforementioned boards.  Thank you for your hard work on this library.  Please accept the pull request at your earliest convenience as this work supports an Arduino to LinuxCNC project https://github.com/AlexmagToast/LinuxCNC_ArduinoConnector [link](https://github.com/AlexmagToast/LinuxCNC_ArduinoConnector)