### PR TITLE
ESP32 ROM Table Support

### DIFF
--- a/src/FastCRC.h
+++ b/src/FastCRC.h
@@ -51,6 +51,10 @@
 #include <Arduino.h>
 #endif
 
+#if defined(ESP32)
+#include <esp32/rom/crc.h>
+#endif
+
 #include <inttypes.h>
 
 
@@ -170,6 +174,9 @@ class FastCRC32
 {
 public:
   FastCRC32();
+
+  uint32_t init_seed(const uint32_t init);
+
   uint32_t crc32(const uint8_t *data, const size_t datalen);		// Alias CRC-32/ADCCP, PKZIP, Ethernet, 802.3
   uint32_t cksum(const uint8_t *data, const size_t datalen);		// Alias CRC-32/POSIX
 


### PR DESCRIPTION
ESP32 already have CRC tables in the ROM blob
https://github.com/espressif/esp-idf/blob/master/components/esp_rom/include/esp32/rom/crc.h

This is an initial commit to open the discussion for an ESP32 specialisation 

I only implemented CRC32 (but not tested checksum mode, only CRC32)

Given the documentation all modes of CRC8 and CRC16 can be implemented

For the moment it is only a draft given:
1. Various CRC8 and CRC16 not implemented
2. [Documentation](https://github.com/espressif/esp-idf/blob/4f3cd0deb9c79c8282da4938a29d265705a57564/components/esp_rom/include/esp32/rom/crc.h#L41-L47) say that you should `bitwise negate (~)` **both** the initial **seed** and the **result**, but I find out that it work (give same result as the library) only if I bitwise negate **only the seed**  